### PR TITLE
Added extra debug and moved setting client timeout to just before the…

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ foo@bar:~/multithread-libevent-echo-server$ cd src
 ### GCC
 
 ```console
-foo@bar:~/multithread-libevent-echo-server$ gcc -o ../build/server.o src/server.c src/workqueue.c -levent -lpthread
+foo@bar:~/multithread-libevent-echo-server/src$ gcc -o ../build/server.o ./server.c ./workqueue.c -levent -lpthread
 ```
 
 ### clang


### PR DESCRIPTION
Suggested patch to Issue #4 Handling of queued clients and timeout.

The read timeout on the client event was originally set at the time of the event accepting the socket connection in on_accept(). The accept is non-blocking so gets executed as soon as an incoming TCP connection arrives. The job was then entered onto the work queue, but not serviced if there were already no free threads available. Result was that the timeout expired before the worker thread could execute a read event, leading to "tail drop" of all events in the queue.

The patch modifies the timeout to be set just before the event is dispatched from the work queue i.e. in server_job_function() when the job has been pulled from the queue and there is a thread available to actually service the job. This means the timer is individual and relative to when the worker thread starts work for this client. Clients may still time out (at their end) waiting for service, but this change avoids the server opening connections and then not providing any service before timing out for all waiting jobs in the work queue.